### PR TITLE
Default economy plugin

### DIFF
--- a/conf/generalConfig.yml
+++ b/conf/generalConfig.yml
@@ -31,3 +31,7 @@ broadcast-on-skill-up: true
 
 # option to allow payment to be made when near a spawner
 #enable-pay-near-spawner: true
+
+# option to choose, which economy plugin should be used as default
+# available options: iConomy, BOSEconomy
+#economy: iConomy

--- a/src/com/zford/jobs/Jobs.java
+++ b/src/com/zford/jobs/Jobs.java
@@ -129,12 +129,12 @@ public class Jobs extends JavaPlugin{
 						if(getServer().getPluginManager().getPlugin("iConomy") != null || 
 								getServer().getPluginManager().getPlugin("BOSEconomy") != null){
 							if(getServer().getPluginManager().getPlugin("iConomy") != null && JobsConfiguration.getInstance().getDefaultEconomy() == null ||
-                JobsConfiguration.getInstance().getEconomyLink().equalsIgnoreCase("iconomy")){
+                JobsConfiguration.getInstance().getDefaultEconomy().equalsIgnoreCase("iconomy")){
 								JobsConfiguration.getInstance().setEconomyLink(new JobsiConomyLink((iConomy)getServer().getPluginManager().getPlugin("iConomy")));
 			                    System.out.println("[Jobs] Successfully linked with iConomy 5+.");
 							}
 							else if(getServer().getPluginManager().getPlugin("BOSEconomy") != null && JobsConfiguration.getInstance().getDefaultEconomy() == null ||
-                JobsConfiguration.getInstance().getEconomyLink().equalsIgnoreCase("boseconomy")){
+                JobsConfiguration.getInstance().getDefaultEconomy().equalsIgnoreCase("boseconomy")){
 								JobsConfiguration.getInstance().setEconomyLink(new JobsBOSEconomyLink((BOSEconomy)getServer().getPluginManager().getPlugin("BOSEconomy")));
 			                    System.out.println("[Jobs] Successfully linked with BOSEconomy.");
 							}

--- a/src/com/zford/jobs/Jobs.java
+++ b/src/com/zford/jobs/Jobs.java
@@ -128,11 +128,13 @@ public class Jobs extends JavaPlugin{
 					if(JobsConfiguration.getInstance().getEconomyLink() == null){
 						if(getServer().getPluginManager().getPlugin("iConomy") != null || 
 								getServer().getPluginManager().getPlugin("BOSEconomy") != null){
-							if(getServer().getPluginManager().getPlugin("iConomy") != null){
+							if(getServer().getPluginManager().getPlugin("iConomy") != null && JobsConfiguration.getInstance().getDefaultEconomy() == null ||
+                JobsConfiguration.getInstance().getEconomyLink().equalsIgnoreCase("iconomy")){
 								JobsConfiguration.getInstance().setEconomyLink(new JobsiConomyLink((iConomy)getServer().getPluginManager().getPlugin("iConomy")));
 			                    System.out.println("[Jobs] Successfully linked with iConomy 5+.");
 							}
-							else if(getServer().getPluginManager().getPlugin("BOSEconomy") != null){
+							else if(getServer().getPluginManager().getPlugin("BOSEconomy") != null && JobsConfiguration.getInstance().getDefaultEconomy() == null ||
+                JobsConfiguration.getInstance().getEconomyLink().equalsIgnoreCase("boseconomy")){
 								JobsConfiguration.getInstance().setEconomyLink(new JobsBOSEconomyLink((BOSEconomy)getServer().getPluginManager().getPlugin("BOSEconomy")));
 			                    System.out.println("[Jobs] Successfully linked with BOSEconomy.");
 							}

--- a/src/com/zford/jobs/config/JobsConfiguration.java
+++ b/src/com/zford/jobs/config/JobsConfiguration.java
@@ -81,6 +81,8 @@ public class JobsConfiguration {
 	private boolean broadcast;
 	// maximum number of jobs a player can join
 	private Integer maxJobs;
+	// default economy plugin
+	private String defaultEconomy;
 	// used slots for each job
 	private HashMap<Job, Integer> usedSlots;
 	// is stats enabled
@@ -181,13 +183,13 @@ public class JobsConfiguration {
             savePeriod = 10;
         }
 			
-		// broadcasting
+		    // broadcasting
         this.broadcast = conf.getBoolean("broadcast-on-skill-up", false);
         
         // enable stats
         this.statsEnabled = conf.getBoolean("enable-stats", false);
 			
-		// enable pay near spawner
+		    // enable pay near spawner
         this.payNearSpawner = conf.getBoolean("enable-pay-near-spawner", false);
         
         // max-jobs
@@ -196,6 +198,9 @@ public class JobsConfiguration {
             System.out.println("[Jobs] - max-jobs property not found. Defaulting to unlimited!");
             maxJobs = null;
         }
+        
+        // default economy plugin to use
+        this.defaultEconomy = conf.getString("economy", "");
 	}
 	
 	/**
@@ -623,6 +628,14 @@ public class JobsConfiguration {
 	 */
 	public int getSavePeriod(){
 		return savePeriod;
+	}
+	
+	/**
+	 * Get which economy plugin should we use
+	 * @return which economy plugin should we use
+	 */
+	public int getDefaultEconomy(){
+		return defaultEconomy;
 	}
 	
 	/**

--- a/src/com/zford/jobs/config/JobsConfiguration.java
+++ b/src/com/zford/jobs/config/JobsConfiguration.java
@@ -634,7 +634,7 @@ public class JobsConfiguration {
 	 * Get which economy plugin should we use
 	 * @return which economy plugin should we use
 	 */
-	public int getDefaultEconomy(){
+	public String getDefaultEconomy(){
 		return defaultEconomy;
 	}
 	


### PR DESCRIPTION
I added option to set, which economy plugin should be used. It's useful when having two worlds with two different plugins.
