### PR TITLE
Adding a unique id field using auto generation to the MySQL table. Best Practices

### DIFF
--- a/src/main/java/me/zford/jobs/dao/JobsDAOMySQL.java
+++ b/src/main/java/me/zford/jobs/dao/JobsDAOMySQL.java
@@ -1,20 +1,20 @@
 /*
  * Jobs Plugin for Bukkit
  * Copyright (C) 2011  Zak Ford <zak.j.ford@gmail.com>
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  */
 
 package me.zford.jobs.dao;
@@ -25,18 +25,18 @@ import java.sql.Statement;
 import me.zford.jobs.Jobs;
 
 public class JobsDAOMySQL extends JobsDAO {
-    
+
     public JobsDAOMySQL(Jobs plugin, String url, String username, String password, String prefix) {
         super(plugin, "com.mysql.jdbc.Driver", url, username, password, prefix);
         setUp();
     }
-    
+
     public void setUp(){
         try{
             JobsConnection conn = getConnection();
             if(conn != null){
                 Statement st = conn.createStatement();
-                String table = "CREATE TABLE IF NOT EXISTS `" + getPrefix() + "jobs` (username varchar(20), experience integer, level integer, job varchar(20));";
+                String table = "CREATE TABLE IF NOT EXISTS `" + getPrefix() + "jobs` (`id` INT NOT NULL AUTO_INCREMENT PRIMARY KEY, `username` varchar(20), `experience` integer, `level` integer, `job` varchar(20));";
                 st.executeUpdate(table);
                 conn.close();
             }


### PR DESCRIPTION
adding an id field that can be used as the primary key, from initial tests this does not break any of the select / insert statements. This serves be more compliant with best practices. Also added ticks to the column names. Again in keeping with best practices
