### PR TITLE
NPE fix from mods brock breakers.

### DIFF
--- a/src/main/java/me/zford/jobs/bukkit/listeners/JobsPaymentListener.java
+++ b/src/main/java/me/zford/jobs/bukkit/listeners/JobsPaymentListener.java
@@ -86,6 +86,9 @@ public class JobsPaymentListener implements Listener {
         if(!plugin.isEnabled()) return;
         
         Player player = event.getPlayer();
+
+        //Check for mods fake-users
+        if(player.getName().equalsIgnoreCase("[redpower]") || player.getName().equalsIgnoreCase("[industrialcraft]") || player.getName().equalsIgnoreCase("[buildcraft]")) return;
         
         // check if in creative
         if (player.getGameMode().equals(GameMode.CREATIVE) && !plugin.getJobsConfiguration().payInCreative())


### PR DESCRIPTION
Fixed NPE when mod machine breaks a block.
Fix for: RedPower, BuildCraft, IndustrialCraft.

Special thanks for muCkk. =)
