### PR TITLE
Factions plugin integration.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,16 +17,21 @@
   </repositories>
   <dependencies>
     <dependency>
-      <groupId>org.bukkit</groupId>
-      <artifactId>bukkit</artifactId>
-      <version>1.2.5-R4.0</version>
-    </dependency>
-    <dependency>
       <groupId>net.milkbowl.vault</groupId>
       <artifactId>Vault</artifactId>
       <version>1.2.12</version>
       <scope>system</scope>
       <systemPath>${basedir}/lib/Vault-1.2.12.jar</systemPath>
+    </dependency>
+    <dependency>
+      <groupId>org.bukkit</groupId>
+      <artifactId>craftbukkit</artifactId>
+      <version>1.2.5-R5.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.massivecraft</groupId>
+      <artifactId>factions</artifactId>
+      <version>1.7.5</version>
     </dependency>
   </dependencies>
   <build>

--- a/src/main/java/me/zford/jobs/bukkit/config/JobsConfiguration.java
+++ b/src/main/java/me/zford/jobs/bukkit/config/JobsConfiguration.java
@@ -145,6 +145,9 @@ public class JobsConfiguration {
         writer.addComment("economy-batch-delay", "Changes how often, in seconds, players are paid out.  Default is 5 seconds.",
                 "Setting this too low may cause tick lag.  Increase this to improve economy performance (at the cost of delays in payment)");
         config.addDefault("economy-batch-delay", 5);
+        writer.addComment("factions-enabled", "Enables or disables factions integration.",
+        "It will allow faction admins and moderators to employ and fire only players who are in their faction.");
+        config.addDefault("factions-enabled", false);
         
         try {
             config.load(f);
@@ -213,6 +216,7 @@ public class JobsConfiguration {
         copySetting(config, writer, "modify-chat");
         copySetting(config, writer, "economy-batch-size");
         copySetting(config, writer, "economy-batch-delay");
+        copySetting(config, writer, "factions-enabled");
         
         // Write back config
         try {
@@ -558,5 +562,8 @@ public class JobsConfiguration {
     
     public synchronized int getEconomyBatchDelay() {
         return config.getInt("economy-batch-delay");
+    }
+        public synchronized boolean isFactionsEnabled() {
+        return config.getBoolean("factions-enabled");
     }
 }

--- a/src/main/java/me/zford/jobs/bukkit/config/MessageConfig.java
+++ b/src/main/java/me/zford/jobs/bukkit/config/MessageConfig.java
@@ -92,7 +92,9 @@ public class MessageConfig {
         ERROR_NO_PERMISSION("ChatColor.REDYou do not have permission to do that!"),
         JOIN_TOO_MANY_JOB("ChatColor.REDYou have joined too many jobs."),
         LEAVE_JOB_FAILED_TOO_MANY("ChatColor.REDYou have joined too many jobs!"),
-        LEAVE_JOB_SUCCESS("You have left the job %jobcolour%%jobname%ChatColor.WHITE.");
+        LEAVE_JOB_SUCCESS("You have left the job %jobcolour%%jobname%ChatColor.WHITE."),
+        CANNOT_EMPLOY_FACTION("ChatColor.REDYou cannot employ a player who is not in your faction. ChatColor.WHITE"),
+        CANNOT_FIRE_FACTION("ChatColor.REDYou cannot fire a player who is not in your faction. ChatColor.WHITE");
         
         private String message;
         

--- a/src/main/java/me/zford/jobs/dao/JobsDriver.java
+++ b/src/main/java/me/zford/jobs/dao/JobsDriver.java
@@ -4,7 +4,9 @@ import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.DriverPropertyInfo;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.util.Properties;
+import java.util.logging.Logger;
 
 public class JobsDriver implements Driver {
     private Driver driver;
@@ -40,5 +42,10 @@ public class JobsDriver implements Driver {
     @Override
     public boolean jdbcCompliant() {
         return driver.jdbcCompliant();
+    }
+
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 }


### PR DESCRIPTION
Added factions plugin integrations (http://dev.bukkit.org/server-mods/factions)

It allows faction leaders (admins) and moderators to employ or fire staff but only in their faction.  This means people can give jobs per faction. There is an option in the configuration to turn it on which defaults to false. It also has configurable messages in the messages config.
