### PR TITLE
Missing permission check for /jobs browse

### DIFF
--- a/src/main/java/me/zford/jobs/bukkit/JobsCommands.java
+++ b/src/main/java/me/zford/jobs/bukkit/JobsCommands.java
@@ -328,6 +328,8 @@ public class JobsCommands implements CommandExecutor {
     public boolean browse(CommandSender sender, String[] args) {
         ArrayList<String> jobs = new ArrayList<String>();
         for (Job job: plugin.getJobsCore().getJobs()) {
+        	if (!plugin.hasJobPermission(sender, job))
+        		continue;
             if (job.getMaxLevel() > 0) {
                 jobs.add(job.getChatColour() + job.getName() + ChatColor.WHITE + " - max lvl: " + job.getMaxLevel());
             } else {

--- a/src/main/java/me/zford/jobs/bukkit/JobsPlugin.java
+++ b/src/main/java/me/zford/jobs/bukkit/JobsPlugin.java
@@ -27,6 +27,7 @@ import me.zford.jobs.bukkit.config.JobsConfiguration;
 import me.zford.jobs.bukkit.config.MessageConfig;
 import me.zford.jobs.bukkit.economy.BufferedEconomy;
 import me.zford.jobs.bukkit.listeners.JobsListener;
+import me.zford.jobs.bukkit.listeners.JobsMcmmoListener;
 import me.zford.jobs.bukkit.listeners.JobsPaymentListener;
 import me.zford.jobs.bukkit.tasks.BufferedPaymentThread;
 import me.zford.jobs.container.ActionInfo;
@@ -110,6 +111,12 @@ public class JobsPlugin extends JavaPlugin {
             return;
         }
         
+        if (loadMcmmo()) {
+        	getServer().getPluginManager().registerEvents(new JobsMcmmoListener(this), this);
+        }else {
+        	getServer().getLogger().severe("Unable to load mcMMO. Repair events will be ignored.");
+        }
+        
         // register the listeners
         getServer().getPluginManager().registerEvents(new JobsListener(this), this);
         getServer().getPluginManager().registerEvents(new JobsPaymentListener(this), this);
@@ -145,6 +152,18 @@ public class JobsPlugin extends JavaPlugin {
         economy = new BufferedEconomy(this);
         
         getLogger().info("["+getDescription().getName()+"] Successfully linked with Vault.");
+        return true;
+    }
+    
+    /**
+     * Loads mcMMO
+     */
+    private boolean loadMcmmo() {
+        Plugin test = getServer().getPluginManager().getPlugin("mcMMO");
+        if (test == null)
+            return false;
+        
+        getLogger().info("["+getDescription().getName()+"] Successfully linked with mcMMO.");
         return true;
     }
     

--- a/src/main/java/me/zford/jobs/bukkit/listeners/JobsMcmmoListener.java
+++ b/src/main/java/me/zford/jobs/bukkit/listeners/JobsMcmmoListener.java
@@ -1,0 +1,69 @@
+/*
+ * Jobs Plugin for Bukkit
+ * Copyright (C) 2011  Zak Ford <zak.j.ford@gmail.com>
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ */
+
+package me.zford.jobs.bukkit.listeners;
+
+import me.zford.jobs.bukkit.JobsPlugin;
+import me.zford.jobs.bukkit.actions.ItemActionInfo;
+import me.zford.jobs.container.ActionType;
+import me.zford.jobs.container.JobsPlayer;
+
+import org.bukkit.GameMode;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+
+import org.bukkit.inventory.ItemStack;
+
+import com.gmail.nossr50.events.skills.McMMOPlayerRepairCheckEvent;
+
+public class JobsMcmmoListener implements Listener {
+	
+    private JobsPlugin plugin;
+    
+    public JobsMcmmoListener(JobsPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler(priority=EventPriority.MONITOR, ignoreCancelled=true)
+    public void onMcMMOPlayerRepairCheck(McMMOPlayerRepairCheckEvent event) {
+    	
+    	if (!plugin.isEnabled()) return;
+
+    	Player player = event.getPlayer();
+    	
+    	if (player == null) return;
+    	
+    	if (player.getGameMode().equals(GameMode.CREATIVE) && !plugin.getJobsConfiguration().payInCreative())
+            return;
+    	
+    	ItemStack repairMaterial = event.getRepairMaterial();
+    	
+    	if (repairMaterial == null)
+            return;
+
+    	ItemStack materialsUsed = new ItemStack(repairMaterial.getType(), 1);
+    	
+    	double multiplier = plugin.getJobsConfiguration().getRestrictedMultiplier(player);
+        JobsPlayer jPlayer = plugin.getPlayerManager().getJobsPlayer(player.getName());
+        plugin.action(jPlayer, new ItemActionInfo(materialsUsed, ActionType.REPAIR), multiplier);
+    }
+}

--- a/src/main/java/me/zford/jobs/container/ActionType.java
+++ b/src/main/java/me/zford/jobs/container/ActionType.java
@@ -8,7 +8,8 @@ public enum ActionType {
     CRAFT("Craft"),
     SMELT("Smelt"),
     BREW("Brew"),
-    ENCHANT("Enchant");
+    ENCHANT("Enchant"),
+    REPAIR("Repair");
     
     private String name;
     private ActionType(String name) {


### PR DESCRIPTION
After updating to 2.8.5 one of my players discovered that all jobs are displayed when using the /jobs browse command. 

I took a look at the code and noticed the permission check was missing, so I added it back.
