### PR TITLE
Fix one file. Fixed bug in servers with mod IndustrialCraft and occasionally - BuildCraft

### DIFF
--- a/src/main/java/me/zford/jobs/bukkit/listeners/JobsPaymentListener.java
+++ b/src/main/java/me/zford/jobs/bukkit/listeners/JobsPaymentListener.java
@@ -87,6 +87,10 @@ public class JobsPaymentListener implements Listener {
         
         Player player = event.getPlayer();
         
+        // check the existence of the player
+        if (player.isEmpty())
+            return;
+        
         // check if in creative
         if (player.getGameMode().equals(GameMode.CREATIVE) && !plugin.getJobsConfiguration().payInCreative())
             return;


### PR DESCRIPTION
Fixed me.zford.jobs.bukkit.listeners.JobsPaymentListener.java:
Added in onBlockBreak event: 

// check the existence of the player
        if (player.isEmpty())
            return;

---

Error occurred during extraction using auto-miner which is not a physical player.
Text error:

[SEVERE] Could not pass event BlockBreakEvent to Jobs
org.bukkit.event.EventException
    at org.bukkit.plugin.java.JavaPluginLoader$1.execute(JavaPluginLoader.java:304)
    at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:62)
    at org.bukkit.plugin.SimplePluginManager.fireEvent(SimplePluginManager.java:482)
    at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:467)
    at ic2.common.TileEntityMiner.mine(TileEntityMiner.java:205)
    at ic2.common.TileEntityMiner.q_(TileEntityMiner.java:65)
    at net.minecraft.server.World.tickEntities(World.java:1275)
    at net.minecraft.server.MinecraftServer.w(MinecraftServer.java:559)
    at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:457)
    at net.minecraft.server.ThreadServerApplication.run(SourceFile:492)
Caused by: java.lang.NullPointerException
    at me.zford.jobs.bukkit.listeners.JobsPaymentListener.onBlockBreak(JobsPaymentListener.java:91)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:601)
    at org.bukkit.plugin.java.JavaPluginLoader$1.execute(JavaPluginLoader.java:302)
    ... 9 more
