### PR TITLE
Fix bug in Industrial Craft 2.

### DIFF
--- a/src/main/java/me/zford/jobs/bukkit/listeners/JobsPaymentListener.java
+++ b/src/main/java/me/zford/jobs/bukkit/listeners/JobsPaymentListener.java
@@ -87,6 +87,9 @@ public class JobsPaymentListener implements Listener {
         
         Player player = event.getPlayer();
         
+        if (!player.isOnline())
+            return;
+        
         // check if in creative
         if (player.getGameMode().equals(GameMode.CREATIVE) && !plugin.getJobsConfiguration().payInCreative())
             return;


### PR DESCRIPTION
Autominer && Terraformer from IC2 generated NullPointerException in onBlockBreak event.

Example error:
[SEVERE] Could not pass event BlockBreakEvent to Jobs
org.bukkit.event.EventException
        at org.bukkit.plugin.java.JavaPluginLoader$1.execute(JavaPluginLoader.ja     va:304)
        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.jav     a:62)
        at org.bukkit.plugin.SimplePluginManager.fireEvent(SimplePluginManager.j     ava:482)
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.j     ava:467)
        at ic2.common.ItemTFBPFlatification.terraform(ItemTFBPFlatification.java     :78)
        at ic2.common.TileEntityTerra.q_(TileEntityTerra.java:74)
        at net.minecraft.server.World.tickEntities(World.java:1275)
        at net.minecraft.server.MinecraftServer.w(MinecraftServer.java:559)
        at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:457)
        at net.minecraft.server.ThreadServerApplication.run(SourceFile:492)
Caused by: java.lang.NullPointerException
        at me.zford.jobs.bukkit.listeners.JobsPaymentListener.onBlockBreak(JobsP     aymentListener.java:91)
        at sun.reflect.GeneratedMethodAccessor87.invoke(Unknown Source)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAcces     sorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:601)
        at org.bukkit.plugin.java.JavaPluginLoader$1.execute(JavaPluginLoader.ja     va:302)
        ... 9 more
