### PR TITLE
Add a limit to what a player can earn over a time limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@
 /.classpath
 /.project
 /.settings/
+
+#intellij
+*.iml
+.idea
+bin
+dist

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>me.zford</groupId>
   <artifactId>jobs</artifactId>
-  <version>2.11.4-SNAPSHOT</version>
+  <version>2.12.4-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Jobs</name>
   <description>A fully configurable plugin that allows you to get paid for playing Minecraft</description>
@@ -22,7 +22,7 @@
     <profile>
       <id>travis</id>
       <properties>
-        <build.version>2.11.${env.TRAVIS_BUILD_NUMBER}</build.version>
+        <build.version>2.12.${env.TRAVIS_BUILD_NUMBER}</build.version>
       </properties>
     </profile>
   </profiles>

--- a/src/main/java/me/zford/jobs/Jobs.java
+++ b/src/main/java/me/zford/jobs/Jobs.java
@@ -335,14 +335,18 @@ public class Jobs {
             Job jobNone = Jobs.getNoneJob();
             if (jobNone != null) {
                 Double income = jobNone.getIncome(info, 1, numjobs);
-                if (income != null)
-                    Jobs.getEconomy().pay(jPlayer, income*multiplier);
+                if (income != null) {
+                    income = jPlayer.calculatePaymentVersusLimit(income*multiplier);
+                    Jobs.getEconomy().pay(jPlayer, income);
+                }
             }
         } else {
             for (JobProgression prog : progression) {
                 int level = prog.getLevel();
                 Double income = prog.getJob().getIncome(info, level, numjobs);
+                income = jPlayer.calculatePaymentVersusLimit(income*multiplier);
                 if (income != null) {
+                    income = jPlayer.calculatePaymentVersusLimit(income*multiplier);
                     Double exp = prog.getJob().getExperience(info, level, numjobs);
                     if (ConfigManager.getJobsConfiguration().addXpPlayer()) {
                         Player player = getServer().getPlayer(jPlayer.getName());
@@ -366,7 +370,7 @@ public class Jobs {
                         }
                     }
                     // give income
-                    Jobs.getEconomy().pay(jPlayer, income*multiplier);
+                    Jobs.getEconomy().pay(jPlayer, income);
                     int oldLevel = prog.getLevel();
                     if (prog.addExperience(exp*multiplier))
                         Jobs.getPlayerManager().performLevelUp(jPlayer, prog.getJob(), oldLevel);

--- a/src/main/java/me/zford/jobs/bukkit/config/BukkitJobsConfiguration.java
+++ b/src/main/java/me/zford/jobs/bukkit/config/BukkitJobsConfiguration.java
@@ -119,6 +119,19 @@ public class BukkitJobsConfiguration extends JobsConfiguration {
                 "Use 0 for no maximum"
         );
         config.addDefault("max-jobs", 3);
+
+        writer.addComment("max-wage",
+                "Maximum amount of money a player can earn in a the pay-period.",
+                "Use 0 for no maximum"
+        );
+        config.addDefault("max-wage", 0);
+
+        writer.addComment("pay-period",
+                "The time range of the limit reset in seconds.",
+                "not used if max-wage is 0",
+                "If set to 0 max-wage is not used"
+        );
+        config.addDefault("pay-period", 86400);
         
         writer.addComment("hide-jobs-without-permission", "Hide jobs from player if they lack the permission to join the job");
         config.addDefault("hide-jobs-without-permission", false);
@@ -203,11 +216,13 @@ public class BukkitJobsConfiguration extends JobsConfiguration {
         addXpPlayer = config.getBoolean("add-xp-player");
         hideJobsWithoutPermission = config.getBoolean("hide-jobs-without-permission");
         maxJobs = config.getInt("max-jobs");
+        maxWage = config.getDouble("max-wage");
+        payPeriod = config.getLong("pay-period");
         payNearSpawner = config.getBoolean("enable-pay-near-spawner");
         modifyChat = config.getBoolean("modify-chat");
         economyBatchDelay = config.getInt("economy-batch-delay");
         saveOnDisconnect = config.getBoolean("save-on-disconnect");
-        
+
         // Make sure we're only copying settings we care about
         copySetting(config, writer, "locale-language");
         copySetting(config, writer, "storage-method");
@@ -220,6 +235,8 @@ public class BukkitJobsConfiguration extends JobsConfiguration {
         copySetting(config, writer, "broadcast-on-skill-up");
         copySetting(config, writer, "broadcast-on-level-up");
         copySetting(config, writer, "max-jobs");
+        copySetting(config, writer, "max-wage");
+        copySetting(config, writer, "pay-period");
         copySetting(config, writer, "hide-jobs-without-permission");
         copySetting(config, writer, "enable-pay-near-spawner");
         copySetting(config, writer, "enable-pay-creative");

--- a/src/main/java/me/zford/jobs/config/JobsConfiguration.java
+++ b/src/main/java/me/zford/jobs/config/JobsConfiguration.java
@@ -42,6 +42,8 @@ public abstract class JobsConfiguration {
     protected boolean modifyChat;
     protected int economyBatchDelay;
     protected boolean saveOnDisconnect;
+    protected Double maxWage;
+    protected long payPeriod;
     
     public abstract void reload();
     
@@ -157,5 +159,13 @@ public abstract class JobsConfiguration {
     
     public synchronized Locale getLocale() {
         return locale;
+    }
+
+    public synchronized Double getMaxWage() {
+        return maxWage;
+    }
+
+    public synchronized long getPayPeriod() {
+        return payPeriod;
     }
 }

--- a/src/main/java/me/zford/jobs/dao/JobsDriver.java
+++ b/src/main/java/me/zford/jobs/dao/JobsDriver.java
@@ -18,11 +18,9 @@
 
 package me.zford.jobs.dao;
 
-import java.sql.Connection;
-import java.sql.Driver;
-import java.sql.DriverPropertyInfo;
-import java.sql.SQLException;
+import java.sql.*;
 import java.util.Properties;
+import java.util.logging.Logger;
 
 public class JobsDriver implements Driver {
     private Driver driver;


### PR DESCRIPTION
JobsDriver complains that it didn't implement method getParentLogger()

remove comment

limits now working on a global basis, will stop players from earning more
once they get to a defined amount using max-daily-wage in
generalConfig.yml will not limit if max-daily-wage is set < 1

added pay period so limit cna be set over a user defined range and hooked
into the action class to do the payment

update build number
