### PR TITLE
Add Estonian Translation

### DIFF
--- a/src/main/resources/i18n/messages_et.properties
+++ b/src/main/resources/i18n/messages_et.properties
@@ -9,7 +9,7 @@ command.help.output.usage = Kasutus: %usage%
 
 command.stats.help = Näita, milline level oled oma valitud töödes.
 command.stats.help.args = [playername]
-command.stats.error.nojob = Palun liituge mõne tööda kõigepealt.
+command.stats.error.nojob = Palun liituge mõne tööga kõigepealt.
 command.stats.output = lvl%joblevel% %jobname% : %jobxp%/%jobmaxxp% xp
 
 command.info.help = Näita, palju iga töö sulle maksab ja mille eest maksab.

--- a/src/main/resources/i18n/messages_et.properties
+++ b/src/main/resources/i18n/messages_et.properties
@@ -1,0 +1,100 @@
+command.admin.error = Tekkis probleem käsuga.
+command.admin.success = Teie käsk on täidetud.
+
+command.error.job = Töö, mille valisite, puudub!
+command.error.permission = Sul ei ole õiguseid seda teha!
+
+command.help.output = Kirjuta /jobs [käsk] ?, et saada rohkem infot käsu kohta.
+command.help.output.usage = Kasutus: %usage%
+
+command.stats.help = Näita, milline level oled oma valitud töödes.
+command.stats.help.args = [playername]
+command.stats.error.nojob = Palun liituge mõne tööda kõigepealt.
+command.stats.output = lvl%joblevel% %jobname% : %jobxp%/%jobmaxxp% xp
+
+command.info.help = Näita, palju iga töö sulle maksab ja mille eest maksab.
+command.info.help.args = [jobname] [action]
+command.info.output.break = Lõhkumine
+command.info.output.break.none = %jobname% ei anna sulle raha plokkide lõhkumise eest.
+command.info.output.place = Place
+command.info.output.place.none = %jobname% ei anna sulle raha plokkide maha paneku eest.
+command.info.output.kill = Kill
+command.info.output.kill.none = %jobname% ei anna sulle raha koletiste tapmise eest.
+command.info.output.fish = Fish
+command.info.output.fish.none = %jobname% ei anna sulle raha kalastamise eest.
+command.info.output.craft = Craft
+command.info.output.craft.none = %jobname% ei anna sulle raha käsitöö eest.
+command.info.output.smelt = Smelt
+command.info.output.smelt.none = %jobname% ei anna sulle raha sulatamise eest.
+command.info.output.brew = Brew
+command.info.output.brew.none = %jobname% ei anna sulle raha pruulimise eest.
+command.info.output.enchant = Enchant
+command.info.output.enchant.none = %jobname% ei anna sulle raha loitsimise eest.
+command.info.output.repair = Repair
+command.info.output.repair.none = %jobname% ei anna sulle raha parandamise eest.
+
+command.playerinfo.help = Näita, palju iga töö teisele mängijale maksab ja mille eest maksab.
+command.playerinfo.help.args = [playername] [jobname] [action]
+
+command.join.help = Liitu valitud tööga.
+command.join.help.args = [jobname]
+command.join.error.alreadyin = Sa oled juba liitunud %jobname% tööga.
+command.join.error.fullslots = Sa ei saa liituda %jobname% tööga, sest sel tööl pole vabu kohti.
+command.join.error.maxjobs = Sa oled juba liitunud piisavate töödega.
+command.join.success = Sa liitusid %jobname% tööga.
+
+command.leave.help = Lahku valitud tööst.
+command.leave.help.args = [jobname]
+command.leave.success = Sa oled lahkunud %jobname% tööst.
+
+command.leaveall.help = Lahku kõikidest töödest.
+command.leaveall.error.nojobs = Sul ei ole ühtegi tööd, millest lahkuda!
+command.leaveall.success = Sa oled lahkunud kõikidest töödest.
+
+command.browse.help = Järjesta kõik võimalikud tööd sulle.
+command.browse.error.nojobs = Ei ole töid, millega saaksid liituda..
+command.browse.output.header = Sulle on lubatud liituda järgmiste töödega:
+command.browse.output.footer = Rohkemaks informatsiooniks kirjuta /jobs info [JobName]
+
+command.fire.help = Vallanda mängija tööst.
+command.fire.help.args = [playername] [jobname]
+command.fire.error.nojob = Mängijal ei ole %jobname% tööd.
+command.fire.output.target = Sind vallandati %jobname% tööst.
+
+command.fireall.help = Vallanda mängija kõigilt tema töödelt.
+command.fireall.help.args = [playername]
+command.fireall.error.nojobs = Mängijal pole töökohti, kust teda vallandada!
+command.fireall.output.target = Sind vallandati kõigilt sinu töödelt.
+
+command.employ.help = Palka mängija tööle.
+command.employ.help.args = [playername] [jobname]
+command.employ.error.alreadyin = Mängijal on juba %jobname% töö.
+command.employ.output.target = Sind palgati %jobname% tööle.
+
+command.transfer.help = Vii mängija vanalt töölt uuele tööle.
+command.transfer.help.args = [playername] [oldjob] [newjob]
+command.transfer.output.target = Sind viid üle %oldjobname% töölt %newjobname% tööle.
+
+command.promote.help = Eduta mängijat X levelit töös.
+command.promote.help.args = [playername] [jobname] [levels]
+command.promote.output.target = Sind edutati %levelsgained% levelit %jobname% töös.
+
+command.demote.help = Alanda mängijat X levelit töös.
+command.demote.help.args = [playername] [jobname] [levels]
+command.demote.output.target = Sind alandati %levelslost% levelit %jobname% töös.
+
+command.grantxp.help = Anna mängijale X oskust töös.
+command.grantxp.help.args = [playername] [jobname] [xp]
+command.grantxp.output.target = Sulle anti %xpgained% oskust %jobname% töös.
+
+command.removexp.help = Eemalda X oskust mängijalt töös.
+command.removexp.help.args = [playername] [jobname] [xp]
+command.removexp.output.target = sinult eemaldati %xplost% oskust %jobname% töös.
+
+command.reload.help = Lae uuesti konfiguratsioonid.
+
+message.skillup.broadcast = %playername% edutati %titlename% %jobname%.
+message.skillup.nobroadcast = Palju õnne, sind edutati %titlename% %jobname%.
+
+message.levelup.broadcast = %playername% on nüüd level %joblevel% %jobname%.
+message.levelup.nobroadcast = Sa oled nüüd level %joblevel% %jobname%.


### PR DESCRIPTION
I am providing a Estonian translation to Jobs plugin for Bukkit. It contains a letter "õ", which is not very supported (looks awkward) by Minecraft. Others "äöü" are compatible with Minecraft. Any problems with the translation should be fowarded to no.on.aadress{[@]}gmail.com .
