### PR TITLE
Fix compilation on Java 7 and total server lock

### DIFF
--- a/src/main/java/me/zford/jobs/container/JobProgression.java
+++ b/src/main/java/me/zford/jobs/container/JobProgression.java
@@ -40,7 +40,7 @@ public class JobProgression {
      * @return false if the job cannot
      */
     public boolean canLevelUp() {
-        return experience >= maxExperience;
+        return experience >= maxExperience && maxExperience > 0;
     }
     
     /**

--- a/src/main/java/me/zford/jobs/dao/JobsDriver.java
+++ b/src/main/java/me/zford/jobs/dao/JobsDriver.java
@@ -22,7 +22,9 @@ import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.DriverPropertyInfo;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.util.Properties;
+import java.util.logging.Logger;
 
 public class JobsDriver implements Driver {
     private Driver driver;
@@ -58,5 +60,10 @@ public class JobsDriver implements Driver {
     @Override
     public boolean jdbcCompliant() {
         return driver.jdbcCompliant();
+    }
+
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        return driver.getParentLogger();
     }
 }


### PR DESCRIPTION
First adds a new method added on JDK 1.7. Second commit fixes a serious bug that causes a total server lock if levels are not used.
